### PR TITLE
fix: update monty.h with declaration for _pop function

### DIFF
--- a/monty.h
+++ b/monty.h
@@ -49,6 +49,7 @@ opcode_func get_op_func(char *str);
 
 /* opcodes.c */
 void _push(stack_t **stack, unsigned int line_number);
+void _pop(stack_t **stack, unsigned int line_number);
 void _pall(stack_t **stack, unsigned int line_number);
 void _pint(stack_t **stack, unsigned int line_number);
 


### PR DESCRIPTION
Updated monty.h with declaration for _pop function in line with project guidelines for all functions to have declaration in header file.